### PR TITLE
Fix unused checkForUpdate callbacks

### DIFF
--- a/www/hockeyapp.js
+++ b/www/hockeyapp.js
@@ -11,7 +11,7 @@ var hockeyapp = {
         exec(success, failure, "HockeyApp", "forceCrash", []);
     },
     checkForUpdate: function(success, failure) {
-        exec(function () {}, function () {}, "HockeyApp", "checkForUpdate", []);
+        exec(success, failure, "HockeyApp", "checkForUpdate", []);
     }
 };
 


### PR DESCRIPTION
You define them in your definition and also return responses in your iOS and Android implementation but never use them. This pull request solve this problem.