### PR TITLE
Added support for auto-sending crash reports.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Including:
 
 ## Methods
 
-- hockeyapp.start(success:function, error:function, autosend:boolean, hockeyapp_id:string):void
+- hockeyapp.start(success:function, error:function, hockeyapp_id:string, autosend:boolean):void
 
 Initialize HockeyApp SDK
 

--- a/src/android/HockeyApp.java
+++ b/src/android/HockeyApp.java
@@ -23,10 +23,9 @@ public class HockeyApp extends CordovaPlugin {
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
         if (action.equals("start")) {
-            String autoSend = args.optString(0);
-            token = args.optString(1);
+            token = args.optString(0);
+            String autoSend = args.optString(1);
             FeedbackManager.register(cordova.getActivity(), token, null);
-            CrashManager.register(cordova.getActivity(), token);
             if (autoSend.equals("true")) {
                 CrashManager.register(cordova.getActivity(), token, new CrashManagerListener() {
                     public boolean shouldAutoUploadCrashes() {

--- a/src/android/HockeyApp.java
+++ b/src/android/HockeyApp.java
@@ -7,6 +7,7 @@ import org.json.JSONArray;
 import net.hockeyapp.android.FeedbackManager;
 import net.hockeyapp.android.UpdateManager;
 import net.hockeyapp.android.CrashManager;
+import net.hockeyapp.android.CrashManagerListener;
 
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -22,9 +23,20 @@ public class HockeyApp extends CordovaPlugin {
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
         if (action.equals("start")) {
-            token = args.optString(0);
+            String autoSend = args.optString(0);
+            token = args.optString(1);
             FeedbackManager.register(cordova.getActivity(), token, null);
             CrashManager.register(cordova.getActivity(), token);
+            if (autoSend.equals("true")) {
+                CrashManager.register(cordova.getActivity(), token, new CrashManagerListener() {
+                    public boolean shouldAutoUploadCrashes() {
+                        return true;
+                    }
+                });
+            } else {
+                CrashManager.register(cordova.getActivity(), token);
+            }
+
             initialized = true;
             callbackContext.success();
             return true;

--- a/src/ios/HockeyApp.m
+++ b/src/ios/HockeyApp.m
@@ -18,9 +18,15 @@
 
     if (initialized == YES) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"hockeyapp cordova plugin: plugin is already started!"];
-    } else if ([arguments count] > 0) {
+    } else if ([arguments count] > 1) {
 
-        NSString* token = [arguments objectAtIndex:0];
+        NSString* autoSend = [arguments objectAtIndex:0];
+        NSString* token = [arguments objectAtIndex:1];
+
+        if ([autoSend isEqual:@"true"]) {
+            [[BITHockeyManager sharedHockeyManager].crashManager setCrashManagerStatus:BITCrashManagerStatusAutoSend];
+        }
+
         [[BITHockeyManager sharedHockeyManager] configureWithIdentifier:token];
         [[BITHockeyManager sharedHockeyManager] startManager];
         [[BITHockeyManager sharedHockeyManager].authenticator authenticateInstallation];
@@ -28,7 +34,7 @@
         initialized = YES;
 
     } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"hockeyapp cordova plugin: token is missing!"];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"hockeyapp cordova plugin: missing arguments!"];
     }
 
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/ios/HockeyApp.m
+++ b/src/ios/HockeyApp.m
@@ -20,8 +20,8 @@
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"hockeyapp cordova plugin: plugin is already started!"];
     } else if ([arguments count] > 1) {
 
-        NSString* autoSend = [arguments objectAtIndex:0];
-        NSString* token = [arguments objectAtIndex:1];
+        NSString* token = [arguments objectAtIndex:0];
+        NSString* autoSend = [arguments objectAtIndex:1];
 
         if ([autoSend isEqual:@"true"]) {
             [[BITHockeyManager sharedHockeyManager].crashManager setCrashManagerStatus:BITCrashManagerStatusAutoSend];

--- a/www/hockeyapp.js
+++ b/www/hockeyapp.js
@@ -1,8 +1,8 @@
 var exec = require('cordova/exec');
 
 var hockeyapp = {
-    start: function(success, failure, token) {
-        exec(success, failure, "HockeyApp", "start", [ token ]);
+    start: function(success, failure, autoSend, token) {
+        exec(success, failure, "HockeyApp", "start", [ autoSend, token ]);
     },
     feedback: function(success, failure) {
         exec(success, failure, "HockeyApp", "feedback", []);

--- a/www/hockeyapp.js
+++ b/www/hockeyapp.js
@@ -1,8 +1,9 @@
 var exec = require('cordova/exec');
 
 var hockeyapp = {
-    start: function(success, failure, autoSend, token) {
-        exec(success, failure, "HockeyApp", "start", [ autoSend, token ]);
+    start: function(success, failure, token, autoSend) {
+        autoSend = (autoSend === true || autoSend === "true") ? true : false;
+        exec(success, failure, "HockeyApp", "start", [ token, autoSend.toString() ]);
     },
     feedback: function(success, failure) {
         exec(success, failure, "HockeyApp", "feedback", []);


### PR DESCRIPTION
Added an additional argument to the start method, that allows the plugin to upload crash reports automatically if set to true. If the argument is set to anything else, or not set at all, the default behaviour will remain the same, that the app will prompt the user if he wants to submit the report.