### PR TITLE
Fix typos and markup issues in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cordova-plugin-hockeyapp
 
-This plugin exposes the HockeyApp SDK for ios and android
+This plugin exposes the HockeyApp SDK for iOS and Android
 
 Including:
 
@@ -22,31 +22,35 @@ Including:
 
 Initialize HockeyApp SDK
 
-When specifying the loginMode, it is recommended that you use the hockeyapp.loginMode enumeration. Available values are:
+When specifying the `loginMode`, it is recommended that you use the `hockeyapp.loginMode` enumeration. Available values are:
 
 - ANONYMOUS: The user will not be prompted to authenticate.
-- EMAIL_ONLY: The user will be prompted to specify a valid email address. You must also pass your appSecret when using this mode.
+- EMAIL_ONLY: The user will be prompted to specify a valid email address. You must also pass your `appSecret` when using this mode.
 - EMAIL_PASSWORD: The user will be prompted for a valid username/password combination.
 - VALIDATE: The user will not be prompted to authenticate, but the app will try to validate with the HockeyApp service.
 
 Important: Only ANONYMOUS is available for iOS devices, other modes will produce an error.
 
-- **hockeyapp.feedback(sucess:function, error:function):void**
+Display tester feedback user interface:
+```
+hockeyapp.feedback(success:function, error:function):void
+```
 
-Display tester feedback UI
+Check for a new version:
+```
+hockeyapp.checkForUpdate(success:function, error:function):void
+```
 
-- **hockeyapp.checkForUpdate(sucess:function, error:function):void**
+Force an app crash:
+```
+hockeyapp.forceCrash():void
+```
 
-Check for a new version
-
-- **hockeyapp.forceCrash():void**
-
-Force crash app
-
-- **hockeyapp.addMetaData(success:function, error:function, data:object):void**
-
-Adds arbitrary metadata to a crash, which will be displayed in crash reports.
+Add arbitrary metadata to a crash, which will be displayed in crash reports:
+```
+hockeyapp.addMetaData(success:function, error:function, data:object):void
+```
 
 ## Warning
 
-On iOS, you need to disable bitcode. add `ENABLE_BITCODE = false` in `platforms/ios/cordova/build-release.xcconfig .
+On iOS, you need to disable Bitcode. Add `ENABLE_BITCODE = false` in `platforms/ios/cordova/build-release.xcconfig`.


### PR DESCRIPTION
Just fixed some typos and tried to improve markup and layout in certain aspects of the readme